### PR TITLE
Don't use test packages.

### DIFF
--- a/test/foobar/foobar_test.py
+++ b/test/foobar/foobar_test.py
@@ -1,5 +1,5 @@
 from foobar.foobar import foobar
 
 
-def foobar_test():
+def test_foobar():
     assert foobar() == 'foobar'


### PR DESCRIPTION
The simplest way to get this working is to simply not use packages in 
the test tree. You only need packages there if test code imports other 
test code. You don't do that currently, so this works. It might not 
scale though depending on how you structure test code over time.